### PR TITLE
Modified regex to parse "info thread" format used by gdb 7.6.0

### DIFF
--- a/gdb_thread_names.py
+++ b/gdb_thread_names.py
@@ -3,7 +3,8 @@ import gdb
 import os
 
 def get_thread_names():
-    thread_regex = re.compile("(\d+)\s+Thread\s+0x[0-9a-f]+\s+\(LWP (\d+)\)")
+    # thread_regex = re.compile("(\d+)\s+Thread\s+0x[0-9a-f]+\s+\(LWP (\d+)\)")
+    thread_regex = re.compile("(\d+)\s+Thread\s\d+\.(\d+)\s0x[0-9a-f].*")
     # Capture the result of 'info threads' to a string
     thread_info = gdb.execute("info threads", False, True)
 


### PR DESCRIPTION
I'm not sure when it happened but the "info thread" format changed which broke your regex. Here's a simple one liner  to fix it.
